### PR TITLE
Fix conflict with parameter named 'value'

### DIFF
--- a/packages/genq_test/lib/json/json_etf.genq.dart
+++ b/packages/genq_test/lib/json/json_etf.genq.dart
@@ -62,9 +62,9 @@ abstract class $ETFCopyWith {
 }
 
 class _$ETFCopyWithImpl implements $ETFCopyWith {
-  final _$ETF value;
+  final _$ETF __value;
 
-  _$ETFCopyWithImpl(this.value);
+  _$ETFCopyWithImpl(this.__value);
 
   @override
   ETF call({
@@ -73,9 +73,9 @@ class _$ETFCopyWithImpl implements $ETFCopyWith {
     Object? price = genq,
   }) {
     return ETF(
-      isin: isin == genq ? value.isin : isin as ISIN,
-      name: name == genq ? value.name : name as String,
-      price: price == genq ? value.price : price as double,
+      isin: isin == genq ? __value.isin : isin as ISIN,
+      name: name == genq ? __value.name : name as String,
+      price: price == genq ? __value.price : price as double,
     );
   }
 }

--- a/tool/generation_test/fixtures/additional_members/input.genq.dart
+++ b/tool/generation_test/fixtures/additional_members/input.genq.dart
@@ -70,9 +70,9 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
@@ -82,10 +82,10 @@ class _$UserCopyWithImpl implements $UserCopyWith {
     Object? address = genq,
   }) {
     return User(
-      name: name == genq ? value.name : name as String,
-      age: age == genq ? value.age : age as int?,
-      registered: registered == genq ? value.registered : registered as bool,
-      address: address == genq ? value.address : address as Address,
+      name: name == genq ? __value.name : name as String,
+      age: age == genq ? __value.age : age as int?,
+      registered: registered == genq ? __value.registered : registered as bool,
+      address: address == genq ? __value.address : address as Address,
     );
   }
 }
@@ -152,9 +152,9 @@ abstract class $AddressCopyWith {
 }
 
 class _$AddressCopyWithImpl implements $AddressCopyWith {
-  final _$Address value;
+  final _$Address __value;
 
-  _$AddressCopyWithImpl(this.value);
+  _$AddressCopyWithImpl(this.__value);
 
   @override
   Address call({
@@ -163,9 +163,9 @@ class _$AddressCopyWithImpl implements $AddressCopyWith {
     Object? city = genq,
   }) {
     return Address(
-      street: street == genq ? value.street : street as String,
-      zipCode: zipCode == genq ? value.zipCode : zipCode as int,
-      city: city == genq ? value.city : city as String,
+      street: street == genq ? __value.street : street as String,
+      zipCode: zipCode == genq ? __value.zipCode : zipCode as int,
+      city: city == genq ? __value.city : city as String,
     );
   }
 }

--- a/tool/generation_test/fixtures/class_with_multiple_param/input.dart
+++ b/tool/generation_test/fixtures/class_with_multiple_param/input.dart
@@ -8,6 +8,7 @@ class User with _$User {
     required String name,
     required int? age,
     required bool registered,
+    required double value,
     required String enumReservedName,
     required String classReservedName,
   }) = _User;

--- a/tool/generation_test/fixtures/class_with_multiple_param/input.genq.dart
+++ b/tool/generation_test/fixtures/class_with_multiple_param/input.genq.dart
@@ -4,6 +4,7 @@ mixin _$User {
   String get name => throw UnimplementedError();
   int? get age => throw UnimplementedError();
   bool get registered => throw UnimplementedError();
+  double get value => throw UnimplementedError();
   String get enumReservedName => throw UnimplementedError();
   String get classReservedName => throw UnimplementedError();
 
@@ -21,6 +22,9 @@ class _User implements User {
   final bool registered;
 
   @override
+  final double value;
+
+  @override
   final String enumReservedName;
 
   @override
@@ -30,6 +34,7 @@ class _User implements User {
     required this.name,
     required this.age,
     required this.registered,
+    required this.value,
     required this.enumReservedName,
     required this.classReservedName,
   });
@@ -39,7 +44,7 @@ class _User implements User {
 
   @override
   String toString() {
-    return "User(name: $name, age: $age, registered: $registered, enumReservedName: $enumReservedName, classReservedName: $classReservedName)";
+    return "User(name: $name, age: $age, registered: $registered, value: $value, enumReservedName: $enumReservedName, classReservedName: $classReservedName)";
   }
 
   @override
@@ -49,6 +54,7 @@ class _User implements User {
     if (!identical(other.name, name) && other.name != name) return false;
     if (!identical(other.age, age) && other.age != age) return false;
     if (!identical(other.registered, registered) && other.registered != registered) return false;
+    if (!identical(other.value, value) && other.value != value) return false;
     if (!identical(other.enumReservedName, enumReservedName) && other.enumReservedName != enumReservedName) return false;
     if (!identical(other.classReservedName, classReservedName) && other.classReservedName != classReservedName) return false;
     return true;
@@ -61,6 +67,7 @@ class _User implements User {
       name,
       age,
       registered,
+      value,
       enumReservedName,
       classReservedName,
     );
@@ -72,30 +79,33 @@ abstract class $UserCopyWith {
     String name,
     int? age,
     bool registered,
+    double value,
     String enumReservedName,
     String classReservedName,
   });
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
     Object? name = genq,
     Object? age = genq,
     Object? registered = genq,
+    Object? value = genq,
     Object? enumReservedName = genq,
     Object? classReservedName = genq,
   }) {
     return User(
-      name: name == genq ? value.name : name as String,
-      age: age == genq ? value.age : age as int?,
-      registered: registered == genq ? value.registered : registered as bool,
-      enumReservedName: enumReservedName == genq ? value.enumReservedName : enumReservedName as String,
-      classReservedName: classReservedName == genq ? value.classReservedName : classReservedName as String,
+      name: name == genq ? __value.name : name as String,
+      age: age == genq ? __value.age : age as int?,
+      registered: registered == genq ? __value.registered : registered as bool,
+      value: value == genq ? __value.value : value as double,
+      enumReservedName: enumReservedName == genq ? __value.enumReservedName : enumReservedName as String,
+      classReservedName: classReservedName == genq ? __value.classReservedName : classReservedName as String,
     );
   }
 }

--- a/tool/generation_test/fixtures/class_with_single_optional_param/input.genq.dart
+++ b/tool/generation_test/fixtures/class_with_single_optional_param/input.genq.dart
@@ -46,16 +46,16 @@ abstract class $TestCopyWith {
 }
 
 class _$TestCopyWithImpl implements $TestCopyWith {
-  final _$Test value;
+  final _$Test __value;
 
-  _$TestCopyWithImpl(this.value);
+  _$TestCopyWithImpl(this.__value);
 
   @override
   Test call({
     Object? param1 = genq,
   }) {
     return Test(
-      param1: param1 == genq ? value.param1 : param1 as int?,
+      param1: param1 == genq ? __value.param1 : param1 as int?,
     );
   }
 }

--- a/tool/generation_test/fixtures/class_with_single_param/input.genq.dart
+++ b/tool/generation_test/fixtures/class_with_single_param/input.genq.dart
@@ -46,16 +46,16 @@ abstract class $TestCopyWith {
 }
 
 class _$TestCopyWithImpl implements $TestCopyWith {
-  final _$Test value;
+  final _$Test __value;
 
-  _$TestCopyWithImpl(this.value);
+  _$TestCopyWithImpl(this.__value);
 
   @override
   Test call({
     Object? param1 = genq,
   }) {
     return Test(
-      param1: param1 == genq ? value.param1 : param1 as int,
+      param1: param1 == genq ? __value.param1 : param1 as int,
     );
   }
 }

--- a/tool/generation_test/fixtures/collection_types/input.genq.dart
+++ b/tool/generation_test/fixtures/collection_types/input.genq.dart
@@ -62,9 +62,9 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
@@ -73,9 +73,9 @@ class _$UserCopyWithImpl implements $UserCopyWith {
     Object? ages = genq,
   }) {
     return User(
-      names: names == genq ? value.names : names as List<String>,
-      properties: properties == genq ? value.properties : properties as Map<String, dynamic>,
-      ages: ages == genq ? value.ages : ages as Set<int>,
+      names: names == genq ? __value.names : names as List<String>,
+      properties: properties == genq ? __value.properties : properties as Map<String, dynamic>,
+      ages: ages == genq ? __value.ages : ages as Set<int>,
     );
   }
 }

--- a/tool/generation_test/fixtures/const_factory/input.genq.dart
+++ b/tool/generation_test/fixtures/const_factory/input.genq.dart
@@ -62,9 +62,9 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
@@ -73,9 +73,9 @@ class _$UserCopyWithImpl implements $UserCopyWith {
     Object? registered = genq,
   }) {
     return User(
-      name: name == genq ? value.name : name as String,
-      age: age == genq ? value.age : age as int?,
-      registered: registered == genq ? value.registered : registered as bool,
+      name: name == genq ? __value.name : name as String,
+      age: age == genq ? __value.age : age as int?,
+      registered: registered == genq ? __value.registered : registered as bool,
     );
   }
 }

--- a/tool/generation_test/fixtures/const_factory_private_constructor/input.genq.dart
+++ b/tool/generation_test/fixtures/const_factory_private_constructor/input.genq.dart
@@ -62,9 +62,9 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
@@ -73,9 +73,9 @@ class _$UserCopyWithImpl implements $UserCopyWith {
     Object? registered = genq,
   }) {
     return User(
-      name: name == genq ? value.name : name as String,
-      age: age == genq ? value.age : age as int?,
-      registered: registered == genq ? value.registered : registered as bool,
+      name: name == genq ? __value.name : name as String,
+      age: age == genq ? __value.age : age as int?,
+      registered: registered == genq ? __value.registered : registered as bool,
     );
   }
 }

--- a/tool/generation_test/fixtures/empty/input.genq.dart
+++ b/tool/generation_test/fixtures/empty/input.genq.dart
@@ -34,9 +34,10 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  // ignore: unused_field
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call() {

--- a/tool/generation_test/fixtures/enum/input.genq.dart
+++ b/tool/generation_test/fixtures/enum/input.genq.dart
@@ -54,9 +54,9 @@ abstract class $AccountCopyWith {
 }
 
 class _$AccountCopyWithImpl implements $AccountCopyWith {
-  final _$Account value;
+  final _$Account __value;
 
-  _$AccountCopyWithImpl(this.value);
+  _$AccountCopyWithImpl(this.__value);
 
   @override
   Account call({
@@ -64,8 +64,8 @@ class _$AccountCopyWithImpl implements $AccountCopyWith {
     Object? accountType = genq,
   }) {
     return Account(
-      email: email == genq ? value.email : email as String,
-      accountType: accountType == genq ? value.accountType : accountType as AccountType,
+      email: email == genq ? __value.email : email as String,
+      accountType: accountType == genq ? __value.accountType : accountType as AccountType,
     );
   }
 }

--- a/tool/generation_test/fixtures/function_types/input.genq.dart
+++ b/tool/generation_test/fixtures/function_types/input.genq.dart
@@ -94,9 +94,9 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
@@ -109,13 +109,13 @@ class _$UserCopyWithImpl implements $UserCopyWith {
     Object? d = genq,
   }) {
     return User(
-      name: name == genq ? value.name : name as String,
-      age: age == genq ? value.age : age as int?,
-      registered: registered == genq ? value.registered : registered as bool,
-      a: a == genq ? value.a : a as int Function(String str),
-      b: b == genq ? value.b : b as bool Function(int value) Function(String str),
-      c: c == genq ? value.c : c as User Function(String str) Function(int value, {String test}) Function(String str),
-      d: d == genq ? value.d : d as void Function(void Function() a, void Function() b) Function(void Function(void Function() d) c),
+      name: name == genq ? __value.name : name as String,
+      age: age == genq ? __value.age : age as int?,
+      registered: registered == genq ? __value.registered : registered as bool,
+      a: a == genq ? __value.a : a as int Function(String str),
+      b: b == genq ? __value.b : b as bool Function(int value) Function(String str),
+      c: c == genq ? __value.c : c as User Function(String str) Function(int value, {String test}) Function(String str),
+      d: d == genq ? __value.d : d as void Function(void Function() a, void Function() b) Function(void Function(void Function() d) c),
     );
   }
 }

--- a/tool/generation_test/fixtures/generics/input.genq.dart
+++ b/tool/generation_test/fixtures/generics/input.genq.dart
@@ -46,16 +46,16 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
     Object? data = genq,
   }) {
     return User(
-      data: data == genq ? value.data : data as T,
+      data: data == genq ? __value.data : data as T,
     );
   }
 }

--- a/tool/generation_test/fixtures/json_basic/input.genq.dart
+++ b/tool/generation_test/fixtures/json_basic/input.genq.dart
@@ -118,9 +118,9 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
@@ -136,16 +136,16 @@ class _$UserCopyWithImpl implements $UserCopyWith {
     Object? someDoubleValueNullable = genq,
   }) {
     return User(
-      name: name == genq ? value.name : name as String,
-      age: age == genq ? value.age : age as int?,
-      registered: registered == genq ? value.registered : registered as bool,
-      address: address == genq ? value.address : address as Address?,
-      birthday: birthday == genq ? value.birthday : birthday as DateTime?,
-      balance: balance == genq ? value.balance : balance as BigInt?,
-      someObject: someObject == genq ? value.someObject : someObject as Object?,
-      someDynamic: someDynamic == genq ? value.someDynamic : someDynamic as dynamic,
-      someDoubleValue: someDoubleValue == genq ? value.someDoubleValue : someDoubleValue as double,
-      someDoubleValueNullable: someDoubleValueNullable == genq ? value.someDoubleValueNullable : someDoubleValueNullable as double?,
+      name: name == genq ? __value.name : name as String,
+      age: age == genq ? __value.age : age as int?,
+      registered: registered == genq ? __value.registered : registered as bool,
+      address: address == genq ? __value.address : address as Address?,
+      birthday: birthday == genq ? __value.birthday : birthday as DateTime?,
+      balance: balance == genq ? __value.balance : balance as BigInt?,
+      someObject: someObject == genq ? __value.someObject : someObject as Object?,
+      someDynamic: someDynamic == genq ? __value.someDynamic : someDynamic as dynamic,
+      someDoubleValue: someDoubleValue == genq ? __value.someDoubleValue : someDoubleValue as double,
+      someDoubleValueNullable: someDoubleValueNullable == genq ? __value.someDoubleValueNullable : someDoubleValueNullable as double?,
     );
   }
 }
@@ -250,9 +250,9 @@ abstract class $AddressCopyWith {
 }
 
 class _$AddressCopyWithImpl implements $AddressCopyWith {
-  final _$Address value;
+  final _$Address __value;
 
-  _$AddressCopyWithImpl(this.value);
+  _$AddressCopyWithImpl(this.__value);
 
   @override
   Address call({
@@ -262,10 +262,10 @@ class _$AddressCopyWithImpl implements $AddressCopyWith {
     Object? zip = genq,
   }) {
     return Address(
-      street: street == genq ? value.street : street as String,
-      city: city == genq ? value.city : city as String,
-      state: state == genq ? value.state : state as String,
-      zip: zip == genq ? value.zip : zip as String,
+      street: street == genq ? __value.street : street as String,
+      city: city == genq ? __value.city : city as String,
+      state: state == genq ? __value.state : state as String,
+      zip: zip == genq ? __value.zip : zip as String,
     );
   }
 }

--- a/tool/generation_test/fixtures/json_collections/input.genq.dart
+++ b/tool/generation_test/fixtures/json_collections/input.genq.dart
@@ -94,9 +94,9 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
@@ -109,13 +109,13 @@ class _$UserCopyWithImpl implements $UserCopyWith {
     Object? addressesMapNullableValue = genq,
   }) {
     return User(
-      addressesList: addressesList == genq ? value.addressesList : addressesList as List<Address>,
-      addressesListNullable: addressesListNullable == genq ? value.addressesListNullable : addressesListNullable as List<Address?>,
-      addressesSet: addressesSet == genq ? value.addressesSet : addressesSet as Set<Address>,
-      addressesSetNullable: addressesSetNullable == genq ? value.addressesSetNullable : addressesSetNullable as Set<Address?>,
-      addressesMap: addressesMap == genq ? value.addressesMap : addressesMap as Map<String, Address>,
-      addressesUriMap: addressesUriMap == genq ? value.addressesUriMap : addressesUriMap as Map<Uri, Address>,
-      addressesMapNullableValue: addressesMapNullableValue == genq ? value.addressesMapNullableValue : addressesMapNullableValue as Map<String, Address?>,
+      addressesList: addressesList == genq ? __value.addressesList : addressesList as List<Address>,
+      addressesListNullable: addressesListNullable == genq ? __value.addressesListNullable : addressesListNullable as List<Address?>,
+      addressesSet: addressesSet == genq ? __value.addressesSet : addressesSet as Set<Address>,
+      addressesSetNullable: addressesSetNullable == genq ? __value.addressesSetNullable : addressesSetNullable as Set<Address?>,
+      addressesMap: addressesMap == genq ? __value.addressesMap : addressesMap as Map<String, Address>,
+      addressesUriMap: addressesUriMap == genq ? __value.addressesUriMap : addressesUriMap as Map<Uri, Address>,
+      addressesMapNullableValue: addressesMapNullableValue == genq ? __value.addressesMapNullableValue : addressesMapNullableValue as Map<String, Address?>,
     );
   }
 }
@@ -190,16 +190,16 @@ abstract class $AddressCopyWith {
 }
 
 class _$AddressCopyWithImpl implements $AddressCopyWith {
-  final _$Address value;
+  final _$Address __value;
 
-  _$AddressCopyWithImpl(this.value);
+  _$AddressCopyWithImpl(this.__value);
 
   @override
   Address call({
     Object? street = genq,
   }) {
     return Address(
-      street: street == genq ? value.street : street as String,
+      street: street == genq ? __value.street : street as String,
     );
   }
 }

--- a/tool/generation_test/fixtures/json_default_value/input.genq.dart
+++ b/tool/generation_test/fixtures/json_default_value/input.genq.dart
@@ -62,9 +62,9 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
@@ -73,9 +73,9 @@ class _$UserCopyWithImpl implements $UserCopyWith {
     Object? registered = genq,
   }) {
     return User(
-      name: name == genq ? value.name : name as String,
-      age: age == genq ? value.age : age as int?,
-      registered: registered == genq ? value.registered : registered as bool,
+      name: name == genq ? __value.name : name as String,
+      age: age == genq ? __value.age : age as int?,
+      registered: registered == genq ? __value.registered : registered as bool,
     );
   }
 }

--- a/tool/generation_test/fixtures/json_enum/input.genq.dart
+++ b/tool/generation_test/fixtures/json_enum/input.genq.dart
@@ -70,9 +70,9 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
@@ -82,10 +82,10 @@ class _$UserCopyWithImpl implements $UserCopyWith {
     Object? status = genq,
   }) {
     return User(
-      name: name == genq ? value.name : name as String,
-      age: age == genq ? value.age : age as int?,
-      registered: registered == genq ? value.registered : registered as bool,
-      status: status == genq ? value.status : status as UserStatus?,
+      name: name == genq ? __value.name : name as String,
+      age: age == genq ? __value.age : age as int?,
+      registered: registered == genq ? __value.registered : registered as bool,
+      status: status == genq ? __value.status : status as UserStatus?,
     );
   }
 }

--- a/tool/generation_test/fixtures/json_enum_custom/input.genq.dart
+++ b/tool/generation_test/fixtures/json_enum_custom/input.genq.dart
@@ -62,9 +62,9 @@ abstract class $AccountCopyWith {
 }
 
 class _$AccountCopyWithImpl implements $AccountCopyWith {
-  final _$Account value;
+  final _$Account __value;
 
-  _$AccountCopyWithImpl(this.value);
+  _$AccountCopyWithImpl(this.__value);
 
   @override
   Account call({
@@ -73,9 +73,9 @@ class _$AccountCopyWithImpl implements $AccountCopyWith {
     Object? age = genq,
   }) {
     return Account(
-      email: email == genq ? value.email : email as String,
-      accountType: accountType == genq ? value.accountType : accountType as Deez,
-      age: age == genq ? value.age : age as int,
+      email: email == genq ? __value.email : email as String,
+      accountType: accountType == genq ? __value.accountType : accountType as Deez,
+      age: age == genq ? __value.age : age as int,
     );
   }
 }

--- a/tool/generation_test/fixtures/json_enum_unknown/input.genq.dart
+++ b/tool/generation_test/fixtures/json_enum_unknown/input.genq.dart
@@ -54,9 +54,9 @@ abstract class $AccountCopyWith {
 }
 
 class _$AccountCopyWithImpl implements $AccountCopyWith {
-  final _$Account value;
+  final _$Account __value;
 
-  _$AccountCopyWithImpl(this.value);
+  _$AccountCopyWithImpl(this.__value);
 
   @override
   Account call({
@@ -64,8 +64,8 @@ class _$AccountCopyWithImpl implements $AccountCopyWith {
     Object? accountType = genq,
   }) {
     return Account(
-      email: email == genq ? value.email : email as String,
-      accountType: accountType == genq ? value.accountType : accountType as AccountType,
+      email: email == genq ? __value.email : email as String,
+      accountType: accountType == genq ? __value.accountType : accountType as AccountType,
     );
   }
 }

--- a/tool/generation_test/fixtures/list_fields/input.genq.dart
+++ b/tool/generation_test/fixtures/list_fields/input.genq.dart
@@ -54,9 +54,9 @@ abstract class $ShoppingCartCopyWith {
 }
 
 class _$ShoppingCartCopyWithImpl implements $ShoppingCartCopyWith {
-  final _$ShoppingCart value;
+  final _$ShoppingCart __value;
 
-  _$ShoppingCartCopyWithImpl(this.value);
+  _$ShoppingCartCopyWithImpl(this.__value);
 
   @override
   ShoppingCart call({
@@ -64,8 +64,8 @@ class _$ShoppingCartCopyWithImpl implements $ShoppingCartCopyWith {
     Object? items = genq,
   }) {
     return ShoppingCart(
-      ownerName: ownerName == genq ? value.ownerName : ownerName as String,
-      items: items == genq ? value.items : items as List<String>,
+      ownerName: ownerName == genq ? __value.ownerName : ownerName as String,
+      items: items == genq ? __value.items : items as List<String>,
     );
   }
 }

--- a/tool/generation_test/fixtures/many_param/input.genq.dart
+++ b/tool/generation_test/fixtures/many_param/input.genq.dart
@@ -198,9 +198,9 @@ abstract class $ManyParamsCopyWith {
 }
 
 class _$ManyParamsCopyWithImpl implements $ManyParamsCopyWith {
-  final _$ManyParams value;
+  final _$ManyParams __value;
 
-  _$ManyParamsCopyWithImpl(this.value);
+  _$ManyParamsCopyWithImpl(this.__value);
 
   @override
   ManyParams call({
@@ -226,26 +226,26 @@ class _$ManyParamsCopyWithImpl implements $ManyParamsCopyWith {
     Object? t = genq,
   }) {
     return ManyParams(
-      a: a == genq ? value.a : a as int,
-      b: b == genq ? value.b : b as int,
-      c: c == genq ? value.c : c as int,
-      d: d == genq ? value.d : d as int,
-      e: e == genq ? value.e : e as int,
-      f: f == genq ? value.f : f as int,
-      g: g == genq ? value.g : g as int,
-      h: h == genq ? value.h : h as int,
-      i: i == genq ? value.i : i as int,
-      j: j == genq ? value.j : j as int,
-      k: k == genq ? value.k : k as int,
-      l: l == genq ? value.l : l as int,
-      m: m == genq ? value.m : m as int,
-      n: n == genq ? value.n : n as int,
-      o: o == genq ? value.o : o as int,
-      p: p == genq ? value.p : p as int,
-      q: q == genq ? value.q : q as int,
-      r: r == genq ? value.r : r as int,
-      s: s == genq ? value.s : s as int,
-      t: t == genq ? value.t : t as int,
+      a: a == genq ? __value.a : a as int,
+      b: b == genq ? __value.b : b as int,
+      c: c == genq ? __value.c : c as int,
+      d: d == genq ? __value.d : d as int,
+      e: e == genq ? __value.e : e as int,
+      f: f == genq ? __value.f : f as int,
+      g: g == genq ? __value.g : g as int,
+      h: h == genq ? __value.h : h as int,
+      i: i == genq ? __value.i : i as int,
+      j: j == genq ? __value.j : j as int,
+      k: k == genq ? __value.k : k as int,
+      l: l == genq ? __value.l : l as int,
+      m: m == genq ? __value.m : m as int,
+      n: n == genq ? __value.n : n as int,
+      o: o == genq ? __value.o : o as int,
+      p: p == genq ? __value.p : p as int,
+      q: q == genq ? __value.q : q as int,
+      r: r == genq ? __value.r : r as int,
+      s: s == genq ? __value.s : s as int,
+      t: t == genq ? __value.t : t as int,
     );
   }
 }

--- a/tool/generation_test/fixtures/multiple_classes_with_multiple_param/input.genq.dart
+++ b/tool/generation_test/fixtures/multiple_classes_with_multiple_param/input.genq.dart
@@ -70,9 +70,9 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
@@ -82,10 +82,10 @@ class _$UserCopyWithImpl implements $UserCopyWith {
     Object? address = genq,
   }) {
     return User(
-      name: name == genq ? value.name : name as String,
-      age: age == genq ? value.age : age as int?,
-      registered: registered == genq ? value.registered : registered as bool,
-      address: address == genq ? value.address : address as Address,
+      name: name == genq ? __value.name : name as String,
+      age: age == genq ? __value.age : age as int?,
+      registered: registered == genq ? __value.registered : registered as bool,
+      address: address == genq ? __value.address : address as Address,
     );
   }
 }
@@ -152,9 +152,9 @@ abstract class $AddressCopyWith {
 }
 
 class _$AddressCopyWithImpl implements $AddressCopyWith {
-  final _$Address value;
+  final _$Address __value;
 
-  _$AddressCopyWithImpl(this.value);
+  _$AddressCopyWithImpl(this.__value);
 
   @override
   Address call({
@@ -163,9 +163,9 @@ class _$AddressCopyWithImpl implements $AddressCopyWith {
     Object? city = genq,
   }) {
     return Address(
-      street: street == genq ? value.street : street as String,
-      zipCode: zipCode == genq ? value.zipCode : zipCode as int,
-      city: city == genq ? value.city : city as String,
+      street: street == genq ? __value.street : street as String,
+      zipCode: zipCode == genq ? __value.zipCode : zipCode as int,
+      city: city == genq ? __value.city : city as String,
     );
   }
 }

--- a/tool/generation_test/fixtures/not_required_param/input.genq.dart
+++ b/tool/generation_test/fixtures/not_required_param/input.genq.dart
@@ -62,9 +62,9 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
@@ -73,9 +73,9 @@ class _$UserCopyWithImpl implements $UserCopyWith {
     Object? registered = genq,
   }) {
     return User(
-      name: name == genq ? value.name : name as String?,
-      age: age == genq ? value.age : age as int?,
-      registered: registered == genq ? value.registered : registered as bool,
+      name: name == genq ? __value.name : name as String?,
+      age: age == genq ? __value.age : age as int?,
+      registered: registered == genq ? __value.registered : registered as bool,
     );
   }
 }

--- a/tool/generation_test/fixtures/parameter_annotations/input.genq.dart
+++ b/tool/generation_test/fixtures/parameter_annotations/input.genq.dart
@@ -62,9 +62,9 @@ abstract class $UserCopyWith {
 }
 
 class _$UserCopyWithImpl implements $UserCopyWith {
-  final _$User value;
+  final _$User __value;
 
-  _$UserCopyWithImpl(this.value);
+  _$UserCopyWithImpl(this.__value);
 
   @override
   User call({
@@ -73,9 +73,9 @@ class _$UserCopyWithImpl implements $UserCopyWith {
     Object? registered = genq,
   }) {
     return User(
-      name: name == genq ? value.name : name as String,
-      age: age == genq ? value.age : age as int?,
-      registered: registered == genq ? value.registered : registered as bool,
+      name: name == genq ? __value.name : name as String,
+      age: age == genq ? __value.age : age as int?,
+      registered: registered == genq ? __value.registered : registered as bool,
     );
   }
 }

--- a/tool/generation_test/fixtures/sealed_classes/input.genq.dart
+++ b/tool/generation_test/fixtures/sealed_classes/input.genq.dart
@@ -34,9 +34,10 @@ abstract class $LoadingStateCopyWith {
 }
 
 class _$LoadingStateCopyWithImpl implements $LoadingStateCopyWith {
-  final _$LoadingState value;
+  // ignore: unused_field
+  final _$LoadingState __value;
 
-  _$LoadingStateCopyWithImpl(this.value);
+  _$LoadingStateCopyWithImpl(this.__value);
 
   @override
   LoadingState call() {
@@ -98,9 +99,9 @@ abstract class $SuccessStateCopyWith {
 }
 
 class _$SuccessStateCopyWithImpl implements $SuccessStateCopyWith {
-  final _$SuccessState value;
+  final _$SuccessState __value;
 
-  _$SuccessStateCopyWithImpl(this.value);
+  _$SuccessStateCopyWithImpl(this.__value);
 
   @override
   SuccessState call({
@@ -108,8 +109,8 @@ class _$SuccessStateCopyWithImpl implements $SuccessStateCopyWith {
     Object? age = genq,
   }) {
     return SuccessState(
-      name: name == genq ? value.name : name as String,
-      age: age == genq ? value.age : age as int,
+      name: name == genq ? __value.name : name as String,
+      age: age == genq ? __value.age : age as int,
     );
   }
 }

--- a/tool/templates/copywith.go
+++ b/tool/templates/copywith.go
@@ -20,9 +20,12 @@ func templateCopyWith(str []string, classDecl GenqClassDeclaration) []string {
 	str = append(str, "")
 
 	str = append(str, fmt.Sprintf("class _$%sCopyWithImpl implements $%sCopyWith {", classDecl.Name, classDecl.Name))
-	str = append(str, indent(2, fmt.Sprintf("final _$%s value;", classDecl.Name)))
+	if len(classDecl.Constructor.ParamList.NamedParams)+len(classDecl.Constructor.ParamList.PositionalParams) == 0 {
+		str = append(str, indent(2, "// ignore: unused_field"))
+	}
+	str = append(str, indent(2, fmt.Sprintf("final _$%s __value;", classDecl.Name)))
 	str = append(str, "")
-	str = append(str, indent(2, fmt.Sprintf("_$%sCopyWithImpl(this.value);", classDecl.Name)))
+	str = append(str, indent(2, fmt.Sprintf("_$%sCopyWithImpl(this.__value);", classDecl.Name)))
 	str = append(str, "")
 	str = append(str, indent(2, fmt.Sprintf("@override")))
 	if len(classDecl.Constructor.ParamList.NamedParams) > 0 {
@@ -34,7 +37,7 @@ func templateCopyWith(str []string, classDecl GenqClassDeclaration) []string {
 
 		str = append(str, indent(4, fmt.Sprintf("return %s(", classDecl.Name)))
 		for _, param := range classDecl.Constructor.ParamList.NamedParams {
-			str = append(str, indent(6, fmt.Sprintf("%s: %s == genq ? value.%s : %s as %s,", param.Name, param.Name, param.Name, param.Name, param.ParamType.String())))
+			str = append(str, indent(6, fmt.Sprintf("%s: %s == genq ? __value.%s : %s as %s,", param.Name, param.Name, param.Name, param.Name, param.ParamType.String())))
 		}
 		str = append(str, indent(4, fmt.Sprintf(");")))
 


### PR DESCRIPTION
There is a conflict when a class has a parameter named `value`
Example:
```dart
@genq
class Example with _$Example {
  factory Example({required int value}) = _Example;
}
```

Generates:
```dart
class _$ExampleCopyWithImpl implements $ExampleCopyWith {
  final _$Example value;

  _$ExampleCopyWithImpl(this.value);

  @override
  Example call({
    Object? value = genq,
  }) {
    return Example(
      value: value == genq ? value.value : value as int,
    );                             ^^^^^
  }
}
```

Which results in the error:
`example.genq.dart:xx:yy: Error: The getter 'value' isn't defined for the class 'Object?'`

The fixed output should use `__value` instead:
```dart
class _$ExampleCopyWithImpl implements $ExampleCopyWith {
  final _$Example __value;

  _$ExampleCopyWithImpl(this.__value);

  @override
  Example call({
    Object? value = genq,
  }) {
    return Example(
      value: value == genq ? __value.value : value as int,
    );
  }
}
```
